### PR TITLE
Add Hive habit repository

### DIFF
--- a/lib/core/services/service_locator.dart
+++ b/lib/core/services/service_locator.dart
@@ -1,0 +1,18 @@
+import 'package:get_it/get_it.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../features/habit/bindings.dart';
+import '../../features/habit/data/models/habit_model.dart';
+import '../../features/habit/data/models/completion_model.dart';
+import '../../features/habit/data/datasources/hive_data_source.dart';
+
+final sl = GetIt.instance;
+
+Future<void> setupLocator() async {
+  await Hive.initFlutter();
+  Hive.registerAdapter(HabitModelAdapter());
+  Hive.registerAdapter(CompletionModelAdapter());
+
+  registerHabitFeature(sl);
+  await sl<HiveDataSource>().init();
+}

--- a/lib/features/habit/bindings.dart
+++ b/lib/features/habit/bindings.dart
@@ -1,0 +1,13 @@
+import 'package:get_it/get_it.dart';
+
+import 'data/datasources/hive_data_source.dart';
+import 'data/repositories/habit_repository_impl.dart';
+import 'domain/habit_repository.dart';
+
+void registerHabitFeature(GetIt sl) {
+  final dataSource = HiveDataSource();
+  sl.registerSingleton<HiveDataSource>(dataSource);
+  sl.registerLazySingleton<HabitRepository>(
+    () => HabitRepositoryImpl(sl<HiveDataSource>()),
+  );
+}

--- a/lib/features/habit/data/datasources/hive_data_source.dart
+++ b/lib/features/habit/data/datasources/hive_data_source.dart
@@ -1,0 +1,32 @@
+import 'package:hive/hive.dart';
+
+import '../models/habit_model.dart';
+import '../models/completion_model.dart';
+
+class HiveDataSource {
+  late Box<HabitModel> _habitBox;
+  late Box<CompletionModel> _completionBox;
+
+  Future<void> init() async {
+    _habitBox = await Hive.openBox<HabitModel>('habits');
+    _completionBox = await Hive.openBox<CompletionModel>('completions');
+  }
+
+  // Habit CRUD
+  Future<int> addHabit(HabitModel habit) => _habitBox.add(habit);
+
+  List<HabitModel> getHabits() => _habitBox.values.toList();
+
+  Future<void> deleteHabit(int key) => _habitBox.delete(key);
+
+  int get habitCount => _habitBox.length;
+
+  // Completion CRUD
+  Future<int> addCompletion(CompletionModel completion) =>
+      _completionBox.add(completion);
+
+  List<CompletionModel> getCompletionsForHabit(int habitKey) =>
+      _completionBox.values
+          .where((c) => c.habitKey == habitKey)
+          .toList();
+}

--- a/lib/features/habit/data/models/completion_model.dart
+++ b/lib/features/habit/data/models/completion_model.dart
@@ -1,0 +1,14 @@
+import 'package:hive/hive.dart';
+
+part 'completion_model.g.dart';
+
+@HiveType(typeId: 1)
+class CompletionModel extends HiveObject {
+  @HiveField(0)
+  final int habitKey;
+
+  @HiveField(1)
+  final DateTime date;
+
+  CompletionModel({required this.habitKey, required this.date});
+}

--- a/lib/features/habit/data/models/completion_model.g.dart
+++ b/lib/features/habit/data/models/completion_model.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'completion_model.dart';
+
+class CompletionModelAdapter extends TypeAdapter<CompletionModel> {
+  @override
+  final int typeId = 1;
+
+  @override
+  CompletionModel read(BinaryReader reader) {
+    return CompletionModel(
+      habitKey: reader.readInt(),
+      date: reader.readDateTime(),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, CompletionModel obj) {
+    writer.writeInt(obj.habitKey);
+    writer.writeDateTime(obj.date);
+  }
+}

--- a/lib/features/habit/data/models/habit_model.dart
+++ b/lib/features/habit/data/models/habit_model.dart
@@ -1,0 +1,11 @@
+import 'package:hive/hive.dart';
+
+part 'habit_model.g.dart';
+
+@HiveType(typeId: 0)
+class HabitModel extends HiveObject {
+  @HiveField(0)
+  final String title;
+
+  HabitModel({required this.title});
+}

--- a/lib/features/habit/data/models/habit_model.g.dart
+++ b/lib/features/habit/data/models/habit_model.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'habit_model.dart';
+
+class HabitModelAdapter extends TypeAdapter<HabitModel> {
+  @override
+  final int typeId = 0;
+
+  @override
+  HabitModel read(BinaryReader reader) {
+    return HabitModel(title: reader.readString());
+  }
+
+  @override
+  void write(BinaryWriter writer, HabitModel obj) {
+    writer.writeString(obj.title);
+  }
+}

--- a/lib/features/habit/data/repositories/habit_repository_impl.dart
+++ b/lib/features/habit/data/repositories/habit_repository_impl.dart
@@ -1,0 +1,27 @@
+import '../../domain/habit_repository.dart';
+import '../datasources/hive_data_source.dart';
+import '../models/completion_model.dart';
+import '../models/habit_model.dart';
+
+class HabitRepositoryImpl implements HabitRepository {
+  final HiveDataSource dataSource;
+
+  HabitRepositoryImpl(this.dataSource);
+
+  @override
+  Future<int> addHabit(HabitModel habit) => dataSource.addHabit(habit);
+
+  @override
+  List<HabitModel> getHabits() => dataSource.getHabits();
+
+  @override
+  Future<void> deleteHabit(int key) => dataSource.deleteHabit(key);
+
+  @override
+  Future<int> addCompletion(CompletionModel completion) =>
+      dataSource.addCompletion(completion);
+
+  @override
+  List<CompletionModel> getCompletionsForHabit(int habitKey) =>
+      dataSource.getCompletionsForHabit(habitKey);
+}

--- a/lib/features/habit/domain/habit_repository.dart
+++ b/lib/features/habit/domain/habit_repository.dart
@@ -1,0 +1,11 @@
+import '../data/models/habit_model.dart';
+import '../data/models/completion_model.dart';
+
+abstract class HabitRepository {
+  Future<int> addHabit(HabitModel habit);
+  List<HabitModel> getHabits();
+  Future<void> deleteHabit(int key);
+
+  Future<int> addCompletion(CompletionModel completion);
+  List<CompletionModel> getCompletionsForHabit(int habitKey);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'routes/app_pages.dart';
+import 'core/services/service_locator.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await setupLocator();
   runApp(const MyApp());
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,9 @@ dependencies:
 
   go_router: ^6.0.0
   provider: ^6.0.0
+  get_it: ^7.6.0
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -41,6 +44,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+  hive_generator: ^2.0.0
+  build_runner: ^2.4.7
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/habit_hive_test.dart
+++ b/test/habit_hive_test.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:habithero1/features/habit/data/datasources/hive_data_source.dart';
+import 'package:habithero1/features/habit/data/models/habit_model.dart';
+import 'package:habithero1/features/habit/data/models/completion_model.dart';
+
+void main() {
+  test('insert habit adds to box', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(HabitModelAdapter());
+    Hive.registerAdapter(CompletionModelAdapter());
+
+    final ds = HiveDataSource();
+    await ds.init();
+    await ds.addHabit(HabitModel(title: 'Test'));    
+
+    expect(ds.habitCount, 1);
+    await dir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- add Hive models for Habit and Completion
- implement Hive data source and repository
- register repository in a new service locator
- wire up initialization in main
- add unit test for adding a habit
- include generated Hive adapters
- add Hive and GetIt dependencies

## Testing
- `git status --short`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_68775b01547083319d7386c66c2fb9c4