### PR TITLE
Implement habit management UI

### DIFF
--- a/lib/features/habit/controllers/habit_controller.dart
+++ b/lib/features/habit/controllers/habit_controller.dart
@@ -1,0 +1,35 @@
+import 'package:get/get.dart';
+import '../data/habit_model.dart';
+import '../data/habit_repository.dart';
+
+class HabitController extends GetxController {
+  HabitController(this._repository);
+
+  final HabitRepository _repository;
+
+  final RxList<Habit> habits = <Habit>[].obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    habits.assignAll(_repository.getAll());
+  }
+
+  void addHabit(Habit habit) {
+    _repository.add(habit);
+    habits.add(habit);
+  }
+
+  void updateHabit(Habit habit) {
+    _repository.update(habit);
+    final index = habits.indexWhere((h) => h.id == habit.id);
+    if (index != -1) {
+      habits[index] = habit;
+    }
+  }
+
+  void deleteHabit(int id) {
+    _repository.delete(id);
+    habits.removeWhere((h) => h.id == id);
+  }
+}

--- a/lib/features/habit/data/habit_model.dart
+++ b/lib/features/habit/data/habit_model.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class Habit {
+  final int id;
+  String name;
+  IconData icon;
+  Color color;
+
+  Habit({required this.id, required this.name, required this.icon, required this.color});
+}

--- a/lib/features/habit/data/habit_repository.dart
+++ b/lib/features/habit/data/habit_repository.dart
@@ -1,0 +1,22 @@
+import 'habit_model.dart';
+
+class HabitRepository {
+  final List<Habit> _habits = [];
+
+  List<Habit> getAll() => List.unmodifiable(_habits);
+
+  void add(Habit habit) {
+    _habits.add(habit);
+  }
+
+  void update(Habit habit) {
+    final index = _habits.indexWhere((h) => h.id == habit.id);
+    if (index != -1) {
+      _habits[index] = habit;
+    }
+  }
+
+  void delete(int id) {
+    _habits.removeWhere((h) => h.id == id);
+  }
+}

--- a/lib/features/habit/presentation/pages/dashboard_page.dart
+++ b/lib/features/habit/presentation/pages/dashboard_page.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../data/habit_repository.dart';
+import '../../controllers/habit_controller.dart';
+import '../widgets/habit_tile.dart';
+import 'habit_form_page.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.put(HabitController(HabitRepository()));
+    return Scaffold(
+      appBar: AppBar(title: const Text('Habits')),
+      body: Obx(() {
+        final habits = controller.habits;
+        return ListView.builder(
+          itemCount: habits.length,
+          itemBuilder: (context, index) {
+            return HabitTile(habit: habits[index], controller: controller);
+          },
+        );
+      }),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Get.to(() => HabitFormPage(controller: controller)),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/features/habit/presentation/pages/habit_form_page.dart
+++ b/lib/features/habit/presentation/pages/habit_form_page.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+import 'package:material_symbols_icons/material_symbols_icons.dart';
+import 'package:get/get.dart';
+import '../../data/habit_model.dart';
+import '../../controllers/habit_controller.dart';
+
+class HabitFormPage extends StatefulWidget {
+  const HabitFormPage({Key? key, required this.controller, this.habit}) : super(key: key);
+
+  final HabitController controller;
+  final Habit? habit;
+
+  @override
+  State<HabitFormPage> createState() => _HabitFormPageState();
+}
+
+class _HabitFormPageState extends State<HabitFormPage> {
+  late TextEditingController _nameController;
+  Color _selectedColor = Colors.blue;
+  IconData _selectedIcon = Icons.star;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.habit?.name ?? '');
+    _selectedColor = widget.habit?.color ?? Colors.blue;
+    _selectedIcon = widget.habit?.icon ?? Icons.star;
+  }
+
+  void _pickIcon() async {
+    final icons = const [
+      Symbols.star,
+      Symbols.favorite,
+      Symbols.flag,
+      Symbols.run_circle,
+    ];
+    IconData? result = await showDialog<IconData>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Pick Icon'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: GridView.builder(
+              shrinkWrap: true,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 4,
+              ),
+              itemCount: icons.length,
+              itemBuilder: (context, index) => IconButton(
+                icon: Icon(icons[index]),
+                onPressed: () => Navigator.pop(context, icons[index]),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+    if (result != null) {
+      setState(() => _selectedIcon = result);
+    }
+  }
+
+  void _pickColor() async {
+    Color tempColor = _selectedColor;
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Pick Color'),
+          content: SingleChildScrollView(
+            child: ColorPicker(
+              pickerColor: tempColor,
+              onColorChanged: (color) => tempColor = color,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, tempColor),
+              child: const Text('Select'),
+            ),
+          ],
+        );
+      },
+    );
+    setState(() => _selectedColor = tempColor);
+  }
+
+  void _save() {
+    if (_nameController.text.trim().isEmpty) return;
+    final habit = Habit(
+      id: widget.habit?.id ?? DateTime.now().millisecondsSinceEpoch,
+      name: _nameController.text.trim(),
+      icon: _selectedIcon,
+      color: _selectedColor,
+    );
+    if (widget.habit == null) {
+      widget.controller.addHabit(habit);
+    } else {
+      widget.controller.updateHabit(habit);
+    }
+    Get.back();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.habit == null ? 'Add Habit' : 'Edit Habit')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Habit Name'),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                TextButton(
+                  onPressed: _pickIcon,
+                  child: const Text('Pick Icon'),
+                ),
+                const SizedBox(width: 16),
+                Icon(_selectedIcon, color: _selectedColor),
+              ],
+            ),
+            Row(
+              children: [
+                TextButton(
+                  onPressed: _pickColor,
+                  child: const Text('Pick Color'),
+                ),
+                const SizedBox(width: 16),
+                Container(width: 24, height: 24, color: _selectedColor),
+              ],
+            ),
+            const Spacer(),
+            ElevatedButton(onPressed: _save, child: const Text('Save')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/habit/presentation/widgets/habit_tile.dart
+++ b/lib/features/habit/presentation/widgets/habit_tile.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import '../../../habit/controllers/habit_controller.dart';
+import '../../../habit/data/habit_model.dart';
+import '../pages/habit_form_page.dart';
+import 'package:get/get.dart';
+
+class HabitTile extends StatelessWidget {
+  const HabitTile({Key? key, required this.habit, required this.controller}) : super(key: key);
+
+  final Habit habit;
+  final HabitController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Slidable(
+      endActionPane: ActionPane(
+        motion: const ScrollMotion(),
+        children: [
+          SlidableAction(
+            onPressed: (_) => Get.to(() => HabitFormPage(controller: controller, habit: habit)),
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+            icon: Icons.edit,
+            label: 'Edit',
+          ),
+          SlidableAction(
+            onPressed: (_) => controller.deleteHabit(habit.id),
+            backgroundColor: Colors.red,
+            foregroundColor: Colors.white,
+            icon: Icons.delete,
+            label: 'Delete',
+          ),
+        ],
+      ),
+      child: ListTile(
+        leading: Icon(habit.icon, color: habit.color),
+        title: Text(habit.name),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'features/habit/presentation/pages/dashboard_page.dart';
+
+void main() {
+  runApp(const HabitHeroApp());
+}
+
+class HabitHeroApp extends StatelessWidget {
+  const HabitHeroApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Habit Hero',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const DashboardPage(),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,20 @@
+name: habit_hero
+description: A privacy-first habit tracker app built with Flutter.
+version: 0.1.0
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  get: ^4.6.5
+  flutter_slidable: ^2.0.0
+  flutter_colorpicker: ^1.0.3
+  material_symbols_icons: ^4.2746.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/test/habit_widget_test.dart
+++ b/test/habit_widget_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:habit_hero/features/habit/presentation/pages/dashboard_page.dart';
+
+void main() {
+  testWidgets('create habit increments tile count', (tester) async {
+    await tester.pumpWidget(
+      const GetMaterialApp(home: DashboardPage()),
+    );
+
+    expect(find.byType(ListTile), findsNothing);
+
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'Read');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListTile), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add Flutter app scaffold and habit features
- implement habit controller, repository, and model
- create dashboard with list of habit tiles
- add habit form page with color and icon pickers
- provide widget test for adding habits
- add required dependencies

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877623560c8833196944c7a624fed62