### PR TITLE
Add heatmap calendar widget and leap year streak test

### DIFF
--- a/lib/features/habit/controllers/habit_controller.dart
+++ b/lib/features/habit/controllers/habit_controller.dart
@@ -32,4 +32,16 @@ class HabitController extends GetxController {
     _repository.delete(id);
     habits.removeWhere((h) => h.id == id);
   }
+
+  Map<DateTime, int> completionsMap(int habitId) {
+    final index = habits.indexWhere((h) => h.id == habitId);
+    if (index == -1) return {};
+    final habit = habits[index];
+    final Map<DateTime, int> map = {};
+    for (final date in habit.completions) {
+      final day = DateTime(date.year, date.month, date.day);
+      map.update(day, (v) => v + 1, ifAbsent: () => 1);
+    }
+    return map;
+  }
 }

--- a/lib/features/habit/data/habit_model.dart
+++ b/lib/features/habit/data/habit_model.dart
@@ -5,6 +5,13 @@ class Habit {
   String name;
   IconData icon;
   Color color;
+  List<DateTime> completions;
 
-  Habit({required this.id, required this.name, required this.icon, required this.color});
+  Habit({
+    required this.id,
+    required this.name,
+    required this.icon,
+    required this.color,
+    this.completions = const [],
+  });
 }

--- a/lib/features/habit/presentation/widgets/habit_tile.dart
+++ b/lib/features/habit/presentation/widgets/habit_tile.dart
@@ -4,12 +4,20 @@ import '../../../habit/controllers/habit_controller.dart';
 import '../../../habit/data/habit_model.dart';
 import '../pages/habit_form_page.dart';
 import 'package:get/get.dart';
+import '../../../../widgets/heatmap_calendar.dart';
 
-class HabitTile extends StatelessWidget {
+class HabitTile extends StatefulWidget {
   const HabitTile({Key? key, required this.habit, required this.controller}) : super(key: key);
 
   final Habit habit;
   final HabitController controller;
+
+  @override
+  State<HabitTile> createState() => _HabitTileState();
+}
+
+class _HabitTileState extends State<HabitTile> {
+  bool _expanded = false;
 
   @override
   Widget build(BuildContext context) {
@@ -18,14 +26,14 @@ class HabitTile extends StatelessWidget {
         motion: const ScrollMotion(),
         children: [
           SlidableAction(
-            onPressed: (_) => Get.to(() => HabitFormPage(controller: controller, habit: habit)),
+            onPressed: (_) => Get.to(() => HabitFormPage(controller: widget.controller, habit: widget.habit)),
             backgroundColor: Colors.blue,
             foregroundColor: Colors.white,
             icon: Icons.edit,
             label: 'Edit',
           ),
           SlidableAction(
-            onPressed: (_) => controller.deleteHabit(habit.id),
+            onPressed: (_) => widget.controller.deleteHabit(widget.habit.id),
             backgroundColor: Colors.red,
             foregroundColor: Colors.white,
             icon: Icons.delete,
@@ -33,9 +41,25 @@ class HabitTile extends StatelessWidget {
           ),
         ],
       ),
-      child: ListTile(
-        leading: Icon(habit.icon, color: habit.color),
-        title: Text(habit.name),
+      child: Column(
+        children: [
+          ListTile(
+            leading: Icon(widget.habit.icon, color: widget.habit.color),
+            title: Text(widget.habit.name),
+            trailing: IconButton(
+              icon: Icon(_expanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down),
+              onPressed: () => setState(() => _expanded = !_expanded),
+            ),
+          ),
+          if (_expanded)
+            GetBuilder<HabitController>(
+              id: 'habit_${widget.habit.id}_heatmap',
+              builder: (_) => HabitHeatmapCalendar(
+                habit: widget.habit,
+                completions: widget.habit.completions,
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/features/habit/utils/streak_utils.dart
+++ b/lib/features/habit/utils/streak_utils.dart
@@ -1,0 +1,18 @@
+int calculateStreak(List<DateTime> dates) {
+  if (dates.isEmpty) return 0;
+  final uniqueDates = dates
+      .map((d) => DateTime(d.year, d.month, d.day))
+      .toSet()
+      .toList()
+    ..sort();
+  int streak = 1;
+  for (int i = uniqueDates.length - 1; i > 0; i--) {
+    final diff = uniqueDates[i].difference(uniqueDates[i - 1]).inDays;
+    if (diff == 1) {
+      streak++;
+    } else if (diff > 1) {
+      break;
+    }
+  }
+  return streak;
+}

--- a/lib/widgets/heatmap_calendar.dart
+++ b/lib/widgets/heatmap_calendar.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
+
+import '../features/habit/data/habit_model.dart';
+
+class HabitHeatmapCalendar extends StatelessWidget {
+  final Habit habit;
+  final List<DateTime> completions;
+
+  const HabitHeatmapCalendar({Key? key, required this.habit, required this.completions}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final Map<DateTime, int> data = {};
+    for (final d in completions) {
+      final day = DateTime(d.year, d.month, d.day);
+      data.update(day, (v) => v + 1, ifAbsent: () => 1);
+    }
+    return HeatMapCalendar(
+      flexible: true,
+      colorMode: ColorMode.color,
+      datasets: data,
+      colorsets: const {
+        1: Colors.green,
+        3: Colors.lightGreen,
+        5: Colors.teal,
+        7: Colors.blue,
+        10: Colors.indigo,
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter_slidable: ^2.0.0
   flutter_colorpicker: ^1.0.3
   material_symbols_icons: ^4.2746.0
+  flutter_heatmap_calendar: ^1.0.5
 
 dev_dependencies:
   flutter_test:

--- a/test/streak_utils_test.dart
+++ b/test/streak_utils_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_hero/features/habit/utils/streak_utils.dart';
+
+void main() {
+  test('streak across leap day', () {
+    final dates = [
+      DateTime(2024, 2, 27),
+      DateTime(2024, 2, 28),
+      DateTime(2024, 2, 29),
+      DateTime(2024, 3, 1),
+    ];
+    expect(calculateStreak(dates), 4);
+  });
+}


### PR DESCRIPTION
## Summary
- include `flutter_heatmap_calendar`
- add completions tracking to `Habit` model and helper in controller
- create `HabitHeatmapCalendar` widget
- display heatmap on expandable habit tiles
- implement streak calculation utility
- cover leap year streak case with a unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776fcd5d3c8331a6b78acde410672d