### PR TITLE
Fix OnboardingController constructor

### DIFF
--- a/lib/features/onboarding/presentation/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/presentation/controller/onboarding_controller.dart
@@ -2,10 +2,37 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class OnboardingController extends GetxController {
-  final pageController = PageController();
+  OnboardingController([this.initialPage = 0]);
+
+  final int initialPage;
+  late final PageController pageController;
   final currentPage = 0.obs;
+
+  @override
+  void onInit() {
+    pageController = PageController(initialPage: initialPage);
+    currentPage.value = initialPage;
+    super.onInit();
+  }
 
   bool get isLastPage => currentPage.value == 1;
 
-  void next(VoidCallback goToDashboard) => isLastPage ? goToDashboard() : pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+  void setPage(int index) => currentPage.value = index;
+
+  void next(VoidCallback goToDashboard) {
+    if (isLastPage) {
+      goToDashboard();
+    } else {
+      pageController.nextPage(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  @override
+  void onClose() {
+    pageController.dispose();
+    super.onClose();
+  }
 }

--- a/lib/features/onboarding/presentation/pages/intro_page.dart
+++ b/lib/features/onboarding/presentation/pages/intro_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
+import 'package:get/get.dart';
 
 import '../controller/onboarding_controller.dart';
 import '../widgets/progress_dots.dart';
@@ -23,8 +23,8 @@ class _IntroPageState extends State<IntroPage> {
   @override
   void initState() {
     super.initState();
-    _pageController = PageController(initialPage: widget.initialPage);
     _controller = OnboardingController(widget.initialPage);
+    _pageController = _controller.pageController;
   }
 
   void _goTo(int index) {
@@ -34,26 +34,31 @@ class _IntroPageState extends State<IntroPage> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider.value(
-      value: _controller,
-      child: Scaffold(
-        body: SafeArea(
-          child: Column(
-            children: [
-              Expanded(
-                child: PageView(
-                  controller: _pageController,
-                  onPageChanged: (i) {
-                    _controller.setPage(i);
-                  },
-                  children: [_IntroSlide(onNext: () => _goTo(1)), PrivacyPage(onNext: () => _goTo(2)), ThemeChoicePage(onComplete: () => context.go('/home'))],
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: _pageController,
+                onPageChanged: _controller.setPage,
+                children: [
+                  _IntroSlide(onNext: () => _goTo(1)),
+                  PrivacyPage(onNext: () => _goTo(2)),
+                  ThemeChoicePage(onComplete: () => context.go('/home')),
+                ],
+              ),
+            ),
+            Obx(
+              () => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: ProgressDots(
+                  count: 3,
+                  activeIndex: _controller.currentPage.value,
                 ),
               ),
-              Consumer<OnboardingController>(
-                builder: (context, controller, _) => Padding(padding: const EdgeInsets.symmetric(vertical: 16), child: ProgressDots(count: 3, activeIndex: controller.page)),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- allow passing initial page to `OnboardingController`
- rework IntroPage to use GetX directly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777cf645408331b236b6bce607e9be