### PR TITLE
Fix onboarding controller initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:get/get.dart';
+
+import 'features/onboarding/presentation/controller/onboarding_controller.dart';
 
 import 'core/services/service_locator.dart';
 import 'routes/app_pages.dart';
@@ -10,7 +13,9 @@ import 'theme_notifier.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
-  final router = createRouter();
+  final onboardingComplete = prefs.getBool('onboarding_complete') ?? false;
+  final router = createRouter(onboardingComplete);
+  Get.lazyPut(() => OnboardingController());
   await setupLocator();
   runApp(MyApp(themeNotifier: ThemeNotifier(prefs), router: router));
 }

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -6,7 +6,7 @@ import '../features/onboarding/presentation/pages/intro_page.dart';
 import '../features/onboarding/presentation/pages/onboarding_pager.dart';
 import 'app_routes.dart';
 
-GoRouter createRouter() {
+GoRouter createRouter(bool onboardingComplete) {
   return GoRouter(
     initialLocation: AppRoutes.onboarding,
     routes: [

--- a/test/onboarding_flow_test.dart
+++ b/test/onboarding_flow_test.dart
@@ -10,7 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() => testWidgets('onboarding flow', (tester) async {
   SharedPreferences.setMockInitialValues({});
   final prefs = await SharedPreferences.getInstance();
-  final router = createRouter();
+  final router = createRouter(false);
 
   await tester.pumpWidget(MyApp(themeNotifier: ThemeNotifier(prefs), router: router));
   await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- add OnboardingController injection to main
- pass onboarding completion flag to router
- update onboarding test

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68777f5c1d308331ba9a7be8556f03f0