### PR TITLE
Fix page controller initialization

### DIFF
--- a/lib/features/onboarding/presentation/pages/intro_page.dart
+++ b/lib/features/onboarding/presentation/pages/intro_page.dart
@@ -23,7 +23,7 @@ class _IntroPageState extends State<IntroPage> {
   @override
   void initState() {
     super.initState();
-    _controller = OnboardingController(widget.initialPage);
+    _controller = Get.put(OnboardingController(widget.initialPage));
     _pageController = _controller.pageController;
   }
 

--- a/lib/features/onboarding/presentation/pages/onboarding_pager.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_pager.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:get/get.dart';
 
 import '../controller/onboarding_controller.dart';
 import '../widgets/progress_dots.dart';
@@ -19,37 +19,34 @@ class _OnboardingPagerState extends State<OnboardingPager> {
   @override
   void initState() {
     super.initState();
-    _controller = OnboardingController();
+    _controller = Get.put(OnboardingController());
   }
 
   @override
   void dispose() {
-    _controller.dispose();
+    Get.delete<OnboardingController>();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider.value(
-      value: _controller,
-      child: Scaffold(
-        body: Stack(
-          children: [
-            PageView(
-              controller: _controller.pageController,
-              onPageChanged: (i) => _controller.setPage(i),
-              children: const [WhatsNewPage(), WelcomePage()],
+    return Scaffold(
+      body: Stack(
+        children: [
+          PageView(
+            controller: _controller.pageController,
+            onPageChanged: _controller.setPage,
+            children: const [WhatsNewPage(), WelcomePage()],
+          ),
+          Positioned(
+            bottom: 16,
+            left: 0,
+            right: 0,
+            child: Obx(
+              () => ProgressDots(count: 2, activeIndex: _controller.currentPage.value),
             ),
-            Positioned(
-              bottom: 16,
-              left: 0,
-              right: 0,
-              child: Consumer<OnboardingController>(
-                builder: (context, c, _) => ProgressDots(count: 2, activeIndex: c.page),
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- initialize page controller via Get.put
- migrate onboarding pager to GetX lifecycle

## Testing
- `flutter pub get`
- `flutter test` *(fails: Expected exactly one matching candidate)*

------
https://chatgpt.com/codex/tasks/task_e_687786951bec833196f745ced9bde179