### PR TITLE
Fix LateInitializationError for onboarding

### DIFF
--- a/lib/features/onboarding/presentation/pages/intro_page.dart
+++ b/lib/features/onboarding/presentation/pages/intro_page.dart
@@ -23,7 +23,7 @@ class _IntroPageState extends State<IntroPage> {
   @override
   void initState() {
     super.initState();
-    _controller = OnboardingController(widget.initialPage);
+    _controller = OnboardingController(widget.initialPage)..onInit();
     _pageController = _controller.pageController;
   }
 

--- a/lib/features/onboarding/presentation/pages/onboarding_pager.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_pager.dart
@@ -19,12 +19,12 @@ class _OnboardingPagerState extends State<OnboardingPager> {
   @override
   void initState() {
     super.initState();
-    _controller = OnboardingController();
+    _controller = OnboardingController()..onInit();
   }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _controller.onClose();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- ensure `PageController` is initialized by calling `onInit` when the
  controller is created
- dispose controller via `onClose` in `OnboardingPager`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687788cbfa18833195b1de433d3b6b40