### PR TITLE
Fix onboarding controller provider usage

### DIFF
--- a/lib/features/onboarding/presentation/pages/onboarding_pager.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_pager.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:get/get.dart';
 
 import '../controller/onboarding_controller.dart';
 import '../widgets/progress_dots.dart';
@@ -19,37 +19,35 @@ class _OnboardingPagerState extends State<OnboardingPager> {
   @override
   void initState() {
     super.initState();
-    _controller = OnboardingController()..onInit();
+    _controller = Get.find<OnboardingController>();
   }
 
   @override
   void dispose() {
     _controller.onClose();
+    Get.delete<OnboardingController>();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Provider<OnboardingController>.value(
-      value: _controller,
-      child: Scaffold(
-        body: Stack(
-          children: [
-            PageView(
-              controller: _controller.pageController,
-              onPageChanged: (i) => _controller.setPage(i),
-              children: const [WhatsNewPage(), WelcomePage()],
+    return Scaffold(
+      body: Stack(
+        children: [
+          PageView(
+            controller: _controller.pageController,
+            onPageChanged: (i) => _controller.setPage(i),
+            children: const [WhatsNewPage(), WelcomePage()],
+          ),
+          Positioned(
+            bottom: 16,
+            left: 0,
+            right: 0,
+            child: Obx(
+              () => ProgressDots(count: 2, activeIndex: _controller.page),
             ),
-            Positioned(
-              bottom: 16,
-              left: 0,
-              right: 0,
-              child: Consumer<OnboardingController>(
-                builder: (context, c, _) => ProgressDots(count: 2, activeIndex: c.page),
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- remove `Provider` usage from onboarding pager
- manage the controller using GetX and update progress dots with `Obx`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687789817be8833182735aa5ff8536af