### PR TITLE
feat(habit): create/edit/delete habits with icon & colour pickers

### DIFF
--- a/lib/features/habit/bindings.dart
+++ b/lib/features/habit/bindings.dart
@@ -3,9 +3,11 @@ import 'package:get_it/get_it.dart';
 import 'data/datasources/hive_data_source.dart';
 import 'data/repositories/habit_repository_impl.dart';
 import 'domain/habit_repository.dart';
+import 'presentation/controller/habit_controller.dart';
 
 void registerHabitFeature(GetIt sl) {
   final dataSource = HiveDataSource();
   sl.registerSingleton<HiveDataSource>(dataSource);
   sl.registerLazySingleton<HabitRepository>(() => HabitRepositoryImpl(sl<HiveDataSource>()));
+  sl.registerLazySingleton<HabitController>(() => HabitController());
 }

--- a/lib/features/habit/presentation/controller/habit_controller.dart
+++ b/lib/features/habit/presentation/controller/habit_controller.dart
@@ -1,0 +1,28 @@
+import 'package:get/get.dart';
+
+class HabitEntity {
+  String? id;
+  String name;
+  String? description;
+  int iconCode;
+  int colorHex;
+  HabitEntity({this.id, required this.name, this.description, required this.iconCode, required this.colorHex});
+}
+
+class HabitController extends GetxController {
+  final habits = <HabitEntity>[].obs;
+
+  void addOrUpdate(HabitEntity h) {
+    if (h.id == null) {
+      h.id = DateTime.now().microsecondsSinceEpoch.toString();
+      habits.add(h);
+    } else {
+      final i = habits.indexWhere((e) => e.id == h.id);
+      if (i != -1) habits[i] = h;
+    }
+  }
+
+  void delete(String id) {
+    habits.removeWhere((e) => e.id == id);
+  }
+}

--- a/lib/features/habit/presentation/pages/dashboard_page.dart
+++ b/lib/features/habit/presentation/pages/dashboard_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../routes/app_routes.dart';
+import '../controller/habit_controller.dart';
+import '../widgets/habit_tile.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = Get.find<HabitController>();
+    return Obx(() {
+      final items = c.habits;
+      return Scaffold(
+        appBar: AppBar(title: const Text('Habits')),
+        body: items.isEmpty
+            ? const Center(child: Text('No habits yet'))
+            : ListView.builder(
+                itemCount: items.length,
+                itemBuilder: (_, i) => HabitTile(
+                  habit: items[i],
+                  onEdit: () => context.push('${AppRoutes.habitForm}/${items[i].id}'),
+                  onDelete: () => _confirmDelete(context, c, items[i].id!),
+                ),
+              ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => context.push(AppRoutes.habitForm),
+          child: const Icon(Icons.add),
+        ),
+      );
+    });
+  }
+
+  Future<void> _confirmDelete(BuildContext context, HabitController c, String id) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete habit?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Delete')),
+        ],
+      ),
+    );
+    if (ok == true) c.delete(id);
+  }
+}

--- a/lib/features/habit/presentation/pages/habit_form_page.dart
+++ b/lib/features/habit/presentation/pages/habit_form_page.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
+
+import '../controller/habit_controller.dart';
+import '../widgets/icon_picker_sheet.dart';
+
+class HabitFormPage extends StatefulWidget {
+  final String? habitId;
+  const HabitFormPage({super.key, this.habitId});
+
+  @override
+  State<HabitFormPage> createState() => _HabitFormPageState();
+}
+
+class _HabitFormPageState extends State<HabitFormPage> {
+  final _name = TextEditingController();
+  int _icon = Icons.star.codePoint;
+  int _color = Colors.blue.value;
+  late HabitController c;
+
+  @override
+  void initState() {
+    super.initState();
+    c = Get.find<HabitController>();
+    final h = c.habits.firstWhereOrNull((e) => e.id == widget.habitId);
+    if (h != null) {
+      _name.text = h.name;
+      _icon = h.iconCode;
+      _color = h.colorHex;
+    }
+    _name.addListener(() => setState(() {}));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = [Colors.red, Colors.green, Colors.blue, Colors.orange, Colors.purple, Colors.teal];
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(icon: const Icon(Icons.close), onPressed: context.pop),
+        title: Text(widget.habitId == null ? 'New Habit' : 'Edit Habit'),
+      ),
+      body: Padding(
+        padding: EdgeInsets.only(left: 16, right: 16, bottom: MediaQuery.of(context).viewInsets.bottom + 70),
+        child: Column(mainAxisSize: MainAxisSize.min, children: [
+          GestureDetector(
+            onTap: () async {
+              final icon = await showModalBottomSheet<int>(context: context, builder: (_) => const IconPickerSheet());
+              if (icon != null) setState(() => _icon = icon);
+            },
+            child: CircleAvatar(radius: 32, backgroundColor: Color(_color), child: Icon(IconData(_icon, fontFamily: 'MaterialIcons'))),
+          ),
+          TextField(controller: _name, decoration: const InputDecoration(labelText: 'Name')),
+          Wrap(spacing: 4, children: [
+            for (final col in colors)
+              GestureDetector(
+                onTap: () => setState(() => _color = col.value),
+                child: Container(width: 32, height: 32, decoration: BoxDecoration(color: col, border: Border.all(color: _color == col.value ? Colors.black : Colors.transparent))),
+              )
+          ])
+        ]),
+      ),
+      bottomSheet: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: _name.text.isEmpty
+                ? null
+                : () {
+                    c.addOrUpdate(HabitEntity(id: widget.habitId, name: _name.text, iconCode: _icon, colorHex: _color));
+                    context.pop();
+                  },
+            child: const Text('Save'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/habit/presentation/widgets/habit_tile.dart
+++ b/lib/features/habit/presentation/widgets/habit_tile.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+
+import '../controller/habit_controller.dart';
+
+class HabitTile extends StatelessWidget {
+  final HabitEntity habit;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  const HabitTile({super.key, required this.habit, required this.onEdit, required this.onDelete});
+
+  @override
+  Widget build(BuildContext context) {
+    return Slidable(
+      key: ValueKey(habit.id),
+      startActionPane: ActionPane(
+        motion: const BehindMotion(),
+        children: [
+          SlidableAction(
+            onPressed: (_) => onEdit(),
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            foregroundColor: Theme.of(context).colorScheme.onPrimary,
+            icon: Icons.edit,
+            label: 'Edit',
+          ),
+        ],
+      ),
+      endActionPane: ActionPane(
+        motion: const BehindMotion(),
+        children: [
+          SlidableAction(
+            onPressed: (_) => onDelete(),
+            backgroundColor: Theme.of(context).colorScheme.error,
+            foregroundColor: Theme.of(context).colorScheme.onError,
+            icon: Icons.delete,
+            label: 'Delete',
+          ),
+        ],
+      ),
+      child: ListTile(
+        leading: Container(
+          width: 40,
+          height: 40,
+          color: Color(habit.colorHex),
+          child: Icon(IconData(habit.iconCode, fontFamily: 'MaterialIcons'), color: Colors.white),
+        ),
+        title: Text(habit.name),
+        subtitle: (habit.description ?? '').isEmpty ? null : Text(habit.description!),
+      ),
+    );
+  }
+}

--- a/lib/features/habit/presentation/widgets/icon_picker_sheet.dart
+++ b/lib/features/habit/presentation/widgets/icon_picker_sheet.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class IconPickerSheet extends StatelessWidget {
+  const IconPickerSheet({super.key});
+
+  static const icons = [
+    Icons.book,
+    Icons.directions_run,
+    Icons.fastfood,
+    Icons.sports_soccer,
+    Icons.pool,
+    Icons.music_note,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.count(
+      crossAxisCount: 6,
+      shrinkWrap: true,
+      children: [
+        for (final i in icons)
+          IconButton(icon: Icon(i), onPressed: () => Navigator.pop(context, i.codePoint)),
+      ],
+    );
+  }
+}

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-import '../features/habit/presentation/pages/home_page.dart';
+import '../features/habit/presentation/pages/dashboard_page.dart';
+import '../features/habit/presentation/pages/habit_form_page.dart';
 import '../features/onboarding/presentation/pages/intro_page.dart';
 import '../features/onboarding/presentation/pages/onboarding_pager.dart';
 import 'app_routes.dart';
@@ -21,8 +22,18 @@ GoRouter createRouter(bool onboardingComplete) {
           ],
         ],
       ),
+      // Dashboard
+      GoRoute(path: AppRoutes.dashboard, builder: (context, state) => const DashboardPage()),
       // Root route
-      GoRoute(path: '/', builder: (context, state) => onboardingComplete ? const HomePage() : const IntroPage(initialPage: 0)),
+      GoRoute(path: '/', builder: (context, state) => onboardingComplete ? const DashboardPage() : const IntroPage(initialPage: 0)),
+      // Habit form
+      GoRoute(
+        path: '${AppRoutes.habitForm}/:id?',
+        builder: (_, state) {
+          final id = state.pathParameters['id'];
+          return HabitFormPage(habitId: id);
+        },
+      ),
     ],
   );
 }

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,4 +1,5 @@
 class AppRoutes {
   static const onboarding = '/onboarding';
   static const dashboard = '/dashboard';
+  static const habitForm = '/habit-form';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   get: ^4.6.6
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  flutter_slidable: ^3.0.0
+  flutter_colorpicker: ^1.0.3
+  icons_plus: ^4.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/test/habit_crud_test.dart
+++ b/test/habit_crud_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:habithero1/features/habit/presentation/controller/habit_controller.dart';
+import 'package:habithero1/features/habit/presentation/pages/dashboard_page.dart';
+import 'package:habithero1/features/habit/presentation/pages/habit_form_page.dart';
+import 'package:habithero1/routes/app_routes.dart';
+
+void main() {
+  testWidgets('habit crud', (tester) async {
+    Get.put(HabitController());
+    final router = GoRouter(
+      initialLocation: AppRoutes.dashboard,
+      routes: [
+        GoRoute(path: AppRoutes.dashboard, builder: (_, __) => const DashboardPage()),
+        GoRoute(
+          path: '${AppRoutes.habitForm}/:id?',
+          builder: (_, state) => HabitFormPage(habitId: state.pathParameters['id']),
+        ),
+      ],
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ListTile), findsNothing);
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, 'Read');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+    expect(find.byType(ListTile), findsOneWidget);
+
+    await tester.drag(find.byType(ListTile), const Offset(-200, 0));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete').first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete').last);
+    await tester.pumpAndSettle();
+    expect(find.byType(ListTile), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add habitForm route and wire up in router
- implement HabitController with basic CRUD
- add dashboard page, habit form bottom sheet, tile widget and simple icon picker
- register HabitController in bindings
- add slidable, colorpicker and icons deps
- widget test covers add and delete flow

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778a9c2b6c833185cc6ffc9d85a38b