### PR TITLE
Fix onboarding navigation with GoRouter

### DIFF
--- a/lib/features/onboarding/presentation/pages/welcome_page.dart
+++ b/lib/features/onboarding/presentation/pages/welcome_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../routes/app_routes.dart';
 import '../../../../core/services/service_locator.dart';
@@ -51,7 +52,7 @@ class WelcomePage extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: () {
                   if (c.isLastPage) {
-                    Get.offAllNamed(AppRoutes.dashboard);
+                    context.go(AppRoutes.dashboard);
                   } else {
                     c.next();
                   }

--- a/lib/features/onboarding/presentation/pages/whats_new_page.dart
+++ b/lib/features/onboarding/presentation/pages/whats_new_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../routes/app_routes.dart';
 import '../controller/onboarding_controller.dart';
@@ -40,7 +41,13 @@ class WhatsNewPage extends StatelessWidget {
                 ],
               ),
             ),
-            SizedBox(width: double.infinity, height: 56, child: ElevatedButton(onPressed: () => c.next(() => Get.offAllNamed(AppRoutes.dashboard)), child: const Text('Continue'))),
+            SizedBox(
+                width: double.infinity,
+                height: 56,
+                child: ElevatedButton(
+                    onPressed: () =>
+                        c.next(() => context.go(AppRoutes.dashboard)),
+                    child: const Text('Continue'))),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- update onboarding pages to use `context.go` for navigation
- add `go_router` import to affected files

## Testing
- `flutter` command not available, tests not run

------
https://chatgpt.com/codex/tasks/task_e_687791b657688331974ea148b6821d44