### PR TITLE
Fix controller lifecycle usage

### DIFF
--- a/lib/features/onboarding/presentation/pages/onboarding_pager.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_pager.dart
@@ -24,7 +24,6 @@ class _OnboardingPagerState extends State<OnboardingPager> {
 
   @override
   void dispose() {
-    _controller.onClose();
     Get.delete<OnboardingController>();
     super.dispose();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:get/get.dart';
 
 import 'features/onboarding/presentation/controller/onboarding_controller.dart';
+import 'features/habit/presentation/controller/habit_controller.dart';
 
 import 'core/services/service_locator.dart';
 import 'core/theme/app_theme.dart';
@@ -20,6 +21,7 @@ Future<void> main() async {
   Get.put(onboardingController);
   sl.registerSingleton<OnboardingController>(onboardingController);
   await setupLocator();
+  Get.put(sl<HabitController>());
   runApp(MyApp(themeNotifier: ThemeNotifier(prefs), router: router));
 }
 


### PR DESCRIPTION
## Summary
- initialize `HabitController` with GetX after setting up the service locator
- avoid double-disposing `OnboardingController` in `OnboardingPager`

## Testing
- `dart format -o none lib/main.dart lib/features/onboarding/presentation/pages/onboarding_pager.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687794f249988331a1b88ff5e5022fdf