### PR TITLE
Fix habit form routing

### DIFF
--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -28,11 +28,12 @@ GoRouter createRouter(bool onboardingComplete) {
       GoRoute(path: '/', builder: (context, state) => onboardingComplete ? const DashboardPage() : const IntroPage(initialPage: 0)),
       // Habit form
       GoRoute(
-        path: '${AppRoutes.habitForm}/:id?',
-        builder: (_, state) {
-          final id = state.params['id'];
-          return HabitFormPage(habitId: id);
-        },
+        path: AppRoutes.habitForm,
+        builder: (_, __) => const HabitFormPage(),
+      ),
+      GoRoute(
+        path: '${AppRoutes.habitForm}/:id',
+        builder: (_, state) => HabitFormPage(habitId: state.params['id']),
       ),
     ],
   );

--- a/test/habit_crud_test.dart
+++ b/test/habit_crud_test.dart
@@ -15,8 +15,9 @@ void main() {
       initialLocation: AppRoutes.dashboard,
       routes: [
         GoRoute(path: AppRoutes.dashboard, builder: (_, __) => const DashboardPage()),
+        GoRoute(path: AppRoutes.habitForm, builder: (_, __) => const HabitFormPage()),
         GoRoute(
-          path: '${AppRoutes.habitForm}/:id?',
+          path: '${AppRoutes.habitForm}/:id',
           builder: (_, state) => HabitFormPage(habitId: state.params['id']),
         ),
       ],


### PR DESCRIPTION
## Summary
- define separate routes for habit form with and without id
- update tests to match new routes

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877978c1e808331825bb52c62dacb72