### PR TITLE
feat(onboarding): two-page flow & continue-navigation fix

### DIFF
--- a/lib/features/onboarding/presentation/pages/onboarding_pager.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_pager.dart
@@ -5,6 +5,7 @@ import '../controller/onboarding_controller.dart';
 import '../widgets/progress_dots.dart';
 import 'welcome_page.dart';
 import 'whats_new_page.dart';
+import '../../../../routes/app_routes.dart';
 
 class OnboardingPager extends StatefulWidget {
   const OnboardingPager({super.key});
@@ -36,7 +37,7 @@ class _OnboardingPagerState extends State<OnboardingPager> {
           children: [
             PageView(
               controller: _controller.pageController,
-              onPageChanged: (i) => _controller.setPage(i),
+              onPageChanged: _controller.setPage,
               children: const [WhatsNewPage(), WelcomePage()],
             ),
             Positioned(
@@ -45,6 +46,19 @@ class _OnboardingPagerState extends State<OnboardingPager> {
               right: 0,
               child: Obx(
                 () => ProgressDots(count: 2, activeIndex: _controller.page),
+              ),
+            ),
+            Positioned(
+              bottom: 16,
+              left: 16,
+              right: 16,
+              child: SizedBox(
+                height: 56,
+                child: ElevatedButton(
+                  onPressed: () => _controller
+                      .next(() => Get.offAllNamed(AppRoutes.dashboard)),
+                  child: const Text('Continue'),
+                ),
               ),
             ),
           ],

--- a/lib/features/onboarding/presentation/pages/welcome_page.dart
+++ b/lib/features/onboarding/presentation/pages/welcome_page.dart
@@ -1,8 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:go_router/go_router.dart';
-
-import '../../../../routes/app_routes.dart';
 import '../../../../core/services/service_locator.dart';
 import '../controller/onboarding_controller.dart';
 
@@ -44,20 +40,6 @@ class WelcomePage extends StatelessWidget {
                   const SizedBox(height: 16),
                   Expanded(child: ListView.builder(itemCount: _features.length, itemBuilder: (context, i) => _featureRow(context, primary, _features[i]))),
                 ],
-              ),
-            ),
-            SizedBox(
-              width: double.infinity,
-              height: 56,
-              child: ElevatedButton(
-                onPressed: () {
-                  if (c.isLastPage) {
-                    context.go(AppRoutes.dashboard);
-                  } else {
-                    c.next();
-                  }
-                },
-                child: const Text('Continue'),
               ),
             ),
           ],

--- a/lib/features/onboarding/presentation/pages/whats_new_page.dart
+++ b/lib/features/onboarding/presentation/pages/whats_new_page.dart
@@ -1,9 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:go_router/go_router.dart';
 
-import '../../../../routes/app_routes.dart';
-import '../controller/onboarding_controller.dart';
 
 class WhatsNewPage extends StatelessWidget {
   const WhatsNewPage({super.key});
@@ -16,7 +12,6 @@ class WhatsNewPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final c = Get.find<OnboardingController>();
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.all(24),
@@ -25,7 +20,9 @@ class WhatsNewPage extends StatelessWidget {
             Expanded(
               child: Column(
                 children: [
-                  SizedBox(height: MediaQuery.of(context).size.height * 0.33, child: const FlutterLogo()),
+                  SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.33,
+                      child: Image.asset('assets/mock_phones.png')),
                   const SizedBox(height: 16),
                   Container(
                     padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
@@ -41,13 +38,7 @@ class WhatsNewPage extends StatelessWidget {
                 ],
               ),
             ),
-            SizedBox(
-                width: double.infinity,
-                height: 56,
-                child: ElevatedButton(
-                    onPressed: () =>
-                        c.next(() => context.go(AppRoutes.dashboard)),
-                    child: const Text('Continue'))),
+
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add `OnboardingPager` button for navigation
- refactor onboarding pages to remove page-specific buttons
- display phones mock image on the "What's New" page
- provide placeholder asset

## Testing
- `flutter test` *(fails: Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68779c1920748331b9a6cd23574f798b