### PR TITLE
Fix GetX navigation setup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'routes/app_pages.dart';
 
 void main() {
@@ -10,7 +11,7 @@ class HabitHeroApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
+    return GetMaterialApp.router(
       title: 'Habit Hero',
       theme: ThemeData(
         useMaterial3: true,


### PR DESCRIPTION
## Summary
- switch from `MaterialApp` to `GetMaterialApp` so GetX navigation works

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779e1ed4a08331bac27047e9e98c44