### PR TITLE
Fix onboarding screens flow

### DIFF
--- a/lib/features/onboarding/presentation/pages/intro_page.dart
+++ b/lib/features/onboarding/presentation/pages/intro_page.dart
@@ -6,6 +6,7 @@ import '../controller/onboarding_controller.dart';
 import '../widgets/progress_dots.dart';
 import 'privacy_page.dart';
 import 'theme_choice_page.dart';
+import '../../../../routes/app_routes.dart';
 
 class IntroPage extends StatefulWidget {
   final int initialPage;
@@ -28,7 +29,7 @@ class _IntroPageState extends State<IntroPage> {
   }
 
   void _goTo(int index) {
-    final paths = ['/', '/privacy', '/theme-choice'];
+    final paths = ['/onboarding', '/onboarding/privacy', '/onboarding/theme-choice'];
     context.go(paths[index]);
   }
 
@@ -45,13 +46,15 @@ class _IntroPageState extends State<IntroPage> {
                 children: [
                   _IntroSlide(onNext: () => _goTo(1)),
                   PrivacyPage(onNext: () => _goTo(2)),
-                  ThemeChoicePage(onComplete: () => context.go('/home')),
+                  ThemeChoicePage(
+                    onComplete: () => context.go(AppRoutes.dashboard),
+                  ),
                 ],
               ),
             ),
             Obx(
               () => Padding(
-                padding: const EdgeInsets.symmetric(vertical: 16),
+                padding: const EdgeInsets.only(bottom: 24),
                 child: ProgressDots(
                   count: 3,
                   activeIndex: _controller.currentPage.value,

--- a/lib/features/onboarding/presentation/pages/theme_choice_page.dart
+++ b/lib/features/onboarding/presentation/pages/theme_choice_page.dart
@@ -5,18 +5,17 @@ import 'package:provider/provider.dart';
 import '../../../../theme_notifier.dart';
 
 /// Page allowing the user to pick a theme when first opening the app.
-class ThemeChoicePage extends StatefulWidget {
+class ThemeChoicePage extends StatelessWidget {
   final VoidCallback onComplete;
 
   const ThemeChoicePage({super.key, required this.onComplete});
 
-  @override
-  State<ThemeChoicePage> createState() => _ThemeChoicePageState();
-}
-
-class _ThemeChoicePageState extends State<ThemeChoicePage> {
-  /// 0 -> light, 1 -> dark, 2 -> system
-  int _selectedTheme = 0;
+  void _choose(BuildContext context, ThemeMode mode) {
+    final notifier = context.read<ThemeNotifier>();
+    notifier.setThemeMode(mode);
+    notifier.completeOnboarding();
+    onComplete();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +39,7 @@ class _ThemeChoicePageState extends State<ThemeChoicePage> {
                   Expanded(
                     child: Center(
                       child: Text(
-                        'Theme Selection',
+                        'Choose Your Theme',
                         style: GoogleFonts.lexend(
                           color: textColor,
                           fontWeight: FontWeight.bold,
@@ -81,7 +80,7 @@ class _ThemeChoicePageState extends State<ThemeChoicePage> {
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16.0),
                       child: Text(
-                        'Select Your Theme',
+                        'Choose Your Theme',
                         textAlign: TextAlign.center,
                         style: GoogleFonts.lexend(
                           color: textColor,
@@ -98,7 +97,7 @@ class _ThemeChoicePageState extends State<ThemeChoicePage> {
                         bottom: 8,
                       ),
                       child: Text(
-                        'Choose light or dark mode to begin.',
+                        'Pick light or dark mode to get started.',
                         textAlign: TextAlign.center,
                         style: GoogleFonts.lexend(
                           color: textColor,
@@ -111,14 +110,48 @@ class _ThemeChoicePageState extends State<ThemeChoicePage> {
                       padding: const EdgeInsets.all(16.0),
                       child: Column(
                         children: [
-                          _themeOption(0, 'Light Mode'),
-                          const SizedBox(height: 12),
-                          _themeOption(1, 'Dark Mode'),
-                          const SizedBox(height: 12),
-                          _themeOption(2, 'System Default'),
+                          SizedBox(
+                            width: double.infinity,
+                            height: 56,
+                            child: ElevatedButton(
+                              onPressed: () => _choose(context, ThemeMode.light),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: bgYellow,
+                                foregroundColor: textColor,
+                              ),
+                              child: const Text('Light Mode'),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          SizedBox(
+                            width: double.infinity,
+                            height: 56,
+                            child: ElevatedButton(
+                              onPressed: () => _choose(context, ThemeMode.dark),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: bgYellow,
+                                foregroundColor: textColor,
+                              ),
+                              child: const Text('Dark Mode'),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          SizedBox(
+                            width: double.infinity,
+                            height: 56,
+                            child: ElevatedButton(
+                              onPressed: () => _choose(context, ThemeMode.system),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: bgYellow,
+                                foregroundColor: textColor,
+                              ),
+                              child: const Text('System Default'),
+                            ),
+                          ),
                         ],
                       ),
                     ),
+                    const SizedBox(height: 24),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
@@ -129,35 +162,7 @@ class _ThemeChoicePageState extends State<ThemeChoicePage> {
                         _dot(true),
                       ],
                     ),
-                    const SizedBox(height: 16),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: SizedBox(
-                        width: double.infinity,
-                        height: 48,
-                        child: ElevatedButton(
-                          onPressed: _onContinue,
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: bgYellow,
-                            foregroundColor: textColor,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(28),
-                            ),
-                            elevation: 0,
-                            textStyle: GoogleFonts.lexend(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
-                          ),
-                          child: const Text(
-                            'Continue',
-                            overflow: TextOverflow.ellipsis,
-                            maxLines: 1,
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 20),
+                    const SizedBox(height: 24),
                   ],
                 ),
               ),
@@ -166,23 +171,6 @@ class _ThemeChoicePageState extends State<ThemeChoicePage> {
         ),
       ),
     );
-  }
-
-  void _onContinue() {
-    final notifier = context.read<ThemeNotifier>();
-    switch (_selectedTheme) {
-      case 0:
-        notifier.setThemeMode(ThemeMode.light);
-        break;
-      case 1:
-        notifier.setThemeMode(ThemeMode.dark);
-        break;
-      case 2:
-      default:
-        notifier.setThemeMode(ThemeMode.system);
-    }
-    notifier.completeOnboarding();
-    widget.onComplete();
   }
 
   Widget _dot(bool active) => Container(
@@ -206,45 +194,4 @@ class _ThemeChoicePageState extends State<ThemeChoicePage> {
           child: Icon(icon, size: 28, color: const Color(0xFF181711)),
         ),
       );
-
-  Widget _themeOption(int value, String title) {
-    const borderColor = Color(0xFFE6E5DB);
-    const textColor = Color(0xFF181711);
-    return InkWell(
-      borderRadius: BorderRadius.circular(16),
-      onTap: () => setState(() => _selectedTheme = value),
-      child: Container(
-        padding: const EdgeInsets.all(15),
-        decoration: BoxDecoration(
-          border: Border.all(
-            color: borderColor,
-            width: 1.5,
-          ),
-          borderRadius: BorderRadius.circular(16),
-        ),
-        child: Row(
-          children: [
-            Radio<int>(
-              value: value,
-              groupValue: _selectedTheme,
-              onChanged: (v) => setState(() => _selectedTheme = v!),
-              activeColor: textColor,
-              fillColor: MaterialStateProperty.all(textColor),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                title,
-                style: GoogleFonts.lexend(
-                  color: textColor,
-                  fontWeight: FontWeight.w500,
-                  fontSize: 16,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -4,17 +4,16 @@ import 'package:go_router/go_router.dart';
 import '../features/habit/presentation/pages/dashboard_page.dart';
 import '../features/habit/presentation/pages/habit_form_page.dart';
 import '../features/onboarding/presentation/pages/intro_page.dart';
-import '../features/onboarding/presentation/pages/onboarding_pager.dart';
 import 'app_routes.dart';
 
 GoRouter createRouter(bool onboardingComplete) {
   return GoRouter(
-    initialLocation: AppRoutes.onboarding,
+    initialLocation: onboardingComplete ? AppRoutes.dashboard : AppRoutes.onboarding,
     routes: [
       // Onboarding route
       GoRoute(
         path: AppRoutes.onboarding,
-        builder: (context, state) => OnboardingPager(),
+        builder: (context, state) => const IntroPage(),
         routes: [
           if (!onboardingComplete) ...[
             GoRoute(path: 'privacy', builder: (context, state) => const IntroPage(initialPage: 1)),
@@ -25,7 +24,7 @@ GoRouter createRouter(bool onboardingComplete) {
       // Dashboard
       GoRoute(path: AppRoutes.dashboard, builder: (context, state) => const DashboardPage()),
       // Root route
-      GoRoute(path: '/', builder: (context, state) => onboardingComplete ? const DashboardPage() : const IntroPage(initialPage: 0)),
+      GoRoute(path: '/', builder: (context, state) => const DashboardPage()),
       // Habit form
       GoRoute(
         path: AppRoutes.habitForm,

--- a/test/onboarding_continue_test.dart
+++ b/test/onboarding_continue_test.dart
@@ -18,9 +18,11 @@ void main() => testWidgets('onboarding continue', (tester) async {
   await tester.pumpWidget(MyApp(themeNotifier: ThemeNotifier(prefs), router: router));
   await tester.pumpAndSettle();
 
-  await tester.tap(find.text('Continue').first);
+  await tester.tap(find.text('Next'));
   await tester.pumpAndSettle();
-  await tester.tap(find.text('Continue').first);
+  await tester.tap(find.text('Next'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('System Default'));
   await tester.pumpAndSettle();
 
   expect(router.location, AppRoutes.dashboard);

--- a/test/onboarding_flow_test.dart
+++ b/test/onboarding_flow_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:habithero1/features/onboarding/presentation/pages/privacy_page.dart';
+import 'package:habithero1/features/onboarding/presentation/pages/theme_choice_page.dart';
 import 'package:habithero1/features/onboarding/presentation/pages/welcome_page.dart';
-import 'package:habithero1/features/onboarding/presentation/pages/whats_new_page.dart';
 import 'package:get/get.dart';
 import 'package:habithero1/main.dart';
 import 'package:habithero1/routes/app_pages.dart';
@@ -19,12 +20,18 @@ void main() => testWidgets('onboarding flow', (tester) async {
 
   await tester.pumpWidget(MyApp(themeNotifier: ThemeNotifier(prefs), router: router));
   await tester.pumpAndSettle();
-  expect(find.byType(WhatsNewPage), findsOneWidget);
+
   expect(find.byType(WelcomePage), findsOneWidget);
-  await tester.tap(find.text('Continue').first);
+  await tester.tap(find.text('Next'));
   await tester.pumpAndSettle();
-  expect(find.byType(WelcomePage), findsOneWidget);
-  await tester.tap(find.text('Continue').first);
+
+  expect(find.byType(PrivacyPage), findsOneWidget);
+  await tester.tap(find.text('Next'));
   await tester.pumpAndSettle();
+
+  expect(find.byType(ThemeChoicePage), findsOneWidget);
+  await tester.tap(find.text('Light Mode'));
+  await tester.pumpAndSettle();
+
   expect(router.location, AppRoutes.dashboard);
 });


### PR DESCRIPTION
## Summary
- start onboarding at /onboarding and route to dashboard when complete
- update IntroPage navigation and progress dots
- simplify ThemeChoicePage with direct theme buttons
- rename headings and fix text
- adjust onboarding tests for 3-screen flow

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877bbd157988331bfc71d29c9d387a3