### PR TITLE
feat(core): hive data layer & repo

### DIFF
--- a/lib/features/habit/bindings.dart
+++ b/lib/features/habit/bindings.dart
@@ -1,5 +1,7 @@
 import 'package:get_it/get_it.dart';
 
+import 'package:get/get.dart';
+
 import 'data/datasources/hive_data_source.dart';
 import 'data/repositories/habit_repository_impl.dart';
 import 'domain/habit_repository.dart';
@@ -8,6 +10,7 @@ import 'presentation/controller/habit_controller.dart';
 void registerHabitFeature(GetIt sl) {
   final dataSource = HiveDataSource();
   sl.registerSingleton<HiveDataSource>(dataSource);
-  sl.registerLazySingleton<HabitRepository>(() => HabitRepositoryImpl(sl<HiveDataSource>()));
-  sl.registerLazySingleton<HabitController>(() => HabitController());
+  sl.registerLazySingleton<HabitRepository>(
+      () => HabitRepositoryImpl(sl<HiveDataSource>()));
+  Get.lazyPut(() => HabitController(sl<HabitRepository>()));
 }

--- a/lib/features/habit/presentation/controller/habit_controller.dart
+++ b/lib/features/habit/presentation/controller/habit_controller.dart
@@ -1,5 +1,7 @@
 import 'package:get/get.dart';
 
+import '../../domain/habit_repository.dart';
+
 class HabitEntity {
   String? id;
   String name;
@@ -10,6 +12,10 @@ class HabitEntity {
 }
 
 class HabitController extends GetxController {
+  final HabitRepository repository;
+
+  HabitController(this.repository);
+
   final habits = <HabitEntity>[].obs;
 
   void addOrUpdate(HabitEntity h) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,6 @@ Future<void> main() async {
   Get.put(onboardingController);
   sl.registerSingleton<OnboardingController>(onboardingController);
   await setupLocator();
-  Get.put(sl<HabitController>());
   runApp(MyApp(themeNotifier: ThemeNotifier(prefs), router: router));
 }
 

--- a/test/habit_crud_test.dart
+++ b/test/habit_crud_test.dart
@@ -4,13 +4,33 @@ import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:habithero1/features/habit/presentation/controller/habit_controller.dart';
+import 'package:habithero1/features/habit/domain/habit_repository.dart';
+import 'package:habithero1/features/habit/data/models/habit_model.dart';
+import 'package:habithero1/features/habit/data/models/completion_model.dart';
 import 'package:habithero1/features/habit/presentation/pages/dashboard_page.dart';
 import 'package:habithero1/features/habit/presentation/pages/habit_form_page.dart';
 import 'package:habithero1/routes/app_routes.dart';
 
+class _FakeRepo implements HabitRepository {
+  @override
+  Future<int> addCompletion(CompletionModel completion) async => 0;
+
+  @override
+  Future<int> addHabit(HabitModel habit) async => 0;
+
+  @override
+  Future<void> deleteHabit(int key) async {}
+
+  @override
+  List<CompletionModel> getCompletionsForHabit(int habitKey) => [];
+
+  @override
+  List<HabitModel> getHabits() => [];
+}
+
 void main() {
   testWidgets('habit crud', (tester) async {
-    Get.put(HabitController());
+    Get.put(HabitController(_FakeRepo()));
     final router = GoRouter(
       initialLocation: AppRoutes.dashboard,
       routes: [

--- a/test/hive_insert_test.dart
+++ b/test/hive_insert_test.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:habithero1/features/habit/data/datasources/hive_data_source.dart';
+import 'package:habithero1/features/habit/data/models/habit_model.dart';
+import 'package:habithero1/features/habit/data/models/completion_model.dart';
+
+void main() {
+  test('insert habit adds to box', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    Hive.registerAdapter(HabitModelAdapter());
+    Hive.registerAdapter(CompletionModelAdapter());
+
+    final ds = HiveDataSource();
+    await ds.init();
+    await ds.addHabit(HabitModel(title: 'Test'));    
+
+    expect(ds.habitCount, 1);
+    await dir.delete(recursive: true);
+  });
+}


### PR DESCRIPTION
## Summary
- wire up Hive data layer using GetIt and GetX
- lazily provide `HabitController` via GetX
- add stub repo for `habit_crud_test`
- include `hive_insert_test` to check Hive insertions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877bf79e130833196dc1884ce6d6a84