### PR TITLE
Add habit provider with streak demo

### DIFF
--- a/lib/features/habit/presentation/pages/add_habit_page.dart
+++ b/lib/features/habit/presentation/pages/add_habit_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../controllers/habit_list_controller.dart';
+import '../providers/habit_provider.dart';
 
 class AddHabitPage extends StatefulWidget {
   const AddHabitPage({super.key});
@@ -33,7 +33,14 @@ class _AddHabitPageState extends State<AddHabitPage> {
               onPressed: () {
                 final title = _controller.text.trim();
                 if (title.isNotEmpty) {
-                  context.read<HabitListController>().addHabit(title);
+                  context.read<HabitProvider>().addHabit(
+                        HabitData(
+                          id: DateTime.now().microsecondsSinceEpoch.toString(),
+                          name: title,
+                          icon: Icons.check,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      );
                   Navigator.of(context).pop(true);
                 }
               },

--- a/lib/features/habit/presentation/pages/home_page.dart
+++ b/lib/features/habit/presentation/pages/home_page.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../../../core/services/service_locator.dart';
-import '../../domain/habit_repository.dart';
-import '../controllers/habit_list_controller.dart';
+import '../providers/habit_provider.dart';
 import 'add_habit_page.dart';
 
 class HomePage extends StatelessWidget {
@@ -12,23 +10,33 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => HabitListController(sl<HabitRepository>()),
-      child: Consumer<HabitListController>(
-        builder: (context, controller, _) {
+      create: (_) => HabitProvider(),
+      child: Consumer<HabitProvider>(
+        builder: (context, provider, _) {
           return Scaffold(
             appBar: AppBar(title: const Text('Habits')),
             body: ListView.builder(
-              itemCount: controller.habits.length,
+              itemCount: provider.habits.length,
               itemBuilder: (_, i) {
-                final habit = controller.habits[i];
-                return ListTile(title: Text(habit.title));
+                final habit = provider.habits[i];
+                final streak = provider.getStreak(habit.id);
+                return ListTile(
+                  leading: CircleAvatar(
+                    backgroundColor: habit.color,
+                    child: Icon(habit.icon, color: Colors.white),
+                  ),
+                  title: Text(habit.name),
+                  subtitle: streak > 0
+                      ? Text('Streak: $streak days')
+                      : const Text('No progress yet'),
+                );
               },
             ),
             floatingActionButton: FloatingActionButton(
               onPressed: () async {
                 final added = await Navigator.of(context).push(MaterialPageRoute(builder: (_) => const AddHabitPage()));
                 if (added == true) {
-                  controller.loadHabits();
+                  // new habit already added via provider
                 }
               },
               child: const Icon(Icons.add),

--- a/lib/features/habit/presentation/providers/habit_provider.dart
+++ b/lib/features/habit/presentation/providers/habit_provider.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+/// Basic habit entity used by [HabitProvider].
+class HabitData {
+  final String id;
+  final String name;
+  final IconData icon;
+  final Color color;
+  int streak;
+
+  HabitData({
+    required this.id,
+    required this.name,
+    required this.icon,
+    required this.color,
+    this.streak = 0,
+  });
+}
+
+/// Represents a completion entry for a habit on a specific date.
+class HabitEntry {
+  final String habitId;
+  final DateTime date;
+  final int level; // 0 = not done, 1-4 = done with intensity
+
+  HabitEntry({
+    required this.habitId,
+    required this.date,
+    this.level = 1,
+  });
+}
+
+/// Simple provider that keeps habits and their completion entries in memory.
+class HabitProvider extends ChangeNotifier {
+  final List<HabitData> _habits = [];
+  final List<HabitEntry> _entries = [];
+
+  List<HabitData> get habits => _habits;
+  List<HabitEntry> get entries => _entries;
+
+  void addHabit(HabitData habit) {
+    _habits.add(habit);
+    notifyListeners();
+  }
+
+  void addEntry(HabitEntry entry) {
+    _entries.add(entry);
+    notifyListeners();
+  }
+
+  /// Returns the current streak (in days) for the given habit.
+  int getStreak(String habitId) {
+    final completedDays = _entries
+        .where((e) => e.habitId == habitId && e.level > 0)
+        .map((e) => DateTime(e.date.year, e.date.month, e.date.day))
+        .toSet()
+        .toList()
+      ..sort((a, b) => b.compareTo(a));
+
+    var streak = 0;
+    var day = DateTime.now();
+    while (completedDays.contains(day)) {
+      streak++;
+      day = day.subtract(const Duration(days: 1));
+    }
+    return streak;
+  }
+
+  /// Placeholder for generating heatmap data from [_entries].
+  Map<String, List<List<int>>> generateHeatmap() {
+    // Implement custom logic if needed. Returned map should contain
+    // months mapped to a 2D grid of completion levels.
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary
- implement a `HabitProvider` with in‑memory habit and entry lists
- update `AddHabitPage` to use the provider when creating habits
- refactor `HomePage` to display habits from `HabitProvider` with basic streak info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877c4bb3f248331afba3dd68afadfe3